### PR TITLE
Add the ability to validate Chart in root directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Directory to search for chart directories under"
     default: "charts"
     required: true
+  regexSkipDir:
+    description: "Skip search in directories matching this regex"
+    default: "\.git"
+    required: false
   kubernetesVersion:
     description: "Version of Kubernetes to validate manifests against"
     default: "master"


### PR DESCRIPTION
This modify the way to find Charts directory to be able to validate a 'single chart' repo, where the helm chart is at the root.
- instead of stopping at the first error, it still process the rest of the charts/values.
- allow to skip directories based by regex

EDIT:
- use the json output from kubeconform to get more readable logs

