### PR TITLE
feat: support remote schema urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ supplying the environment variables yourself:
       env:
         ADDITIONAL_SCHEMA_PATHS: |
           schemas/{{ .ResourceKind }}.json
+          https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json
         CHARTS_DIRECTORY: "charts"
         KUBECONFORM_STRICT: "true"
         HELM_UPDATE_DEPENDENCIES: "true"

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: true
   regexSkipDir:
     description: "Skip search in directories matching this regex"
-    default: "\.git"
+    default: "\\.git"
     required: false
   kubernetesVersion:
     description: "Version of Kubernetes to validate manifests against"

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type Config struct {
 	Strict                bool   `env:"KUBECONFORM_STRICT" envDefault:"true"`
 	AdditionalSchemaPaths []Path `env:"ADDITIONAL_SCHEMA_PATHS" envSeparator:"\n"`
 	ChartsDirectory       Path   `env:"CHARTS_DIRECTORY"`
-	RegexSkipDir          string `env:"REGEX_SKIP_DIR" envDefault:"\.git"`
+	RegexSkipDir          string `env:"REGEX_SKIP_DIR" envDefault:"\\.git"`
 	KubernetesVersion     string `env:"KUBERNETES_VERSION" envDefault:"master"`
 	Kubeconform           Path   `env:"KUBECONFORM"`
 	Helm                  Path   `env:"HELM"`
@@ -68,7 +68,7 @@ func main() {
 
 	zerolog.SetGlobalLevel(level)
 
-	log.Trace().Msgf("Config: %s", cfg)
+	log.Trace().Msgf("Config: %v", cfg)
 
 	additionalSchemaPaths := []string{}
 
@@ -248,6 +248,11 @@ func parsePath(raw string) (interface{}, error) {
 
 	if v == "" {
 		return Path{path: ""}, nil
+	}
+
+	if regexp.MustCompile(`^https?://.+$`).MatchString(v) {
+		log.Trace().Msgf("%s is URL", v)
+		return Path{path: v}, nil
 	}
 
 	parsed, err := filepath.Abs(v)


### PR DESCRIPTION
Kubeconform allows to specify templated URL pointing to resource schema.
This commit adds support of this option.

Also, there are minor fixes for incorrectly escaped character.
